### PR TITLE
Connect forms to backend API

### DIFF
--- a/approve.html
+++ b/approve.html
@@ -25,12 +25,24 @@
     <h1 class="mb-3">Aprobar Proyecto</h1>
     <form id="approveForm" class="form">
       <div class="mb-3">
-        <label for="projectId" class="form-label">ID Proyecto</label>
-        <input type="number" class="form-control" id="projectId" name="projectId" placeholder="ID" />
+        <label for="id" class="form-label">ID Proyecto</label>
+        <input type="number" class="form-control" id="id" name="id" placeholder="ID" />
       </div>
       <div class="mb-3">
-        <label for="step" class="form-label">Paso</label>
-        <input type="text" class="form-control" id="step" name="step" placeholder="Paso a aprobar" />
+        <label for="stepId" class="form-label">ID Paso</label>
+        <input type="number" class="form-control" id="stepId" name="stepId" placeholder="ID del paso" />
+      </div>
+      <div class="mb-3">
+        <label for="approverId" class="form-label">ID Aprobador</label>
+        <input type="number" class="form-control" id="approverId" name="approverId" placeholder="Usuario que aprueba" />
+      </div>
+      <div class="mb-3">
+        <label for="state" class="form-label">Estado</label>
+        <input type="text" class="form-control" id="state" name="state" placeholder="Estado del paso" />
+      </div>
+      <div class="mb-3">
+        <label for="message" class="form-label">Observación</label>
+        <input type="text" class="form-control" id="message" name="message" placeholder="Mensaje" />
       </div>
       <button type="submit" class="btn btn-success">Aprobar</button>
     </form>
@@ -43,6 +55,13 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/forms.js"></script>
-  <script>setupForm({formId: 'approveForm', endpoint: 'https://localhost:7062/api/Project/approve', method: 'PUT'});</script>
+  <script>
+    setupForm({
+      formId: 'approveForm',
+      endpoint: 'https://localhost:7062/api/Project/{id}/decision',
+      method: 'PUT',
+      pathParams: ['id']
+    });
+  </script>
 </body>
 </html>

--- a/edit.html
+++ b/edit.html
@@ -36,6 +36,10 @@
         <label for="description" class="form-label">Descripción</label>
         <input type="text" class="form-control" id="description" name="description" placeholder="Nueva descripción" />
       </div>
+      <div class="mb-3">
+        <label for="estimatedDuration" class="form-label">Duración Estimada (días)</label>
+        <input type="number" class="form-control" id="estimatedDuration" name="estimatedDuration" placeholder="Ej: 10" />
+      </div>
       <button type="submit" class="btn btn-success">Guardar cambios</button>
     </form>
     <div id="result" class="result"></div>
@@ -47,6 +51,13 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/forms.js"></script>
-  <script>setupForm({formId: 'editForm', endpoint: 'https://localhost:7062/api/Project', method: 'PUT'});</script>
+  <script>
+    setupForm({
+      formId: 'editForm',
+      endpoint: 'https://localhost:7062/api/Project/{id}',
+      method: 'PUT',
+      pathParams: ['id']
+    });
+  </script>
 </body>
 </html>

--- a/js/forms.js
+++ b/js/forms.js
@@ -15,13 +15,23 @@ function setupForm(config) {
           payload[key] = value;
         }
       }
+
+      let endpoint = config.endpoint;
+      if (config.pathParams) {
+        for (const param of config.pathParams) {
+          const val = payload[param];
+          endpoint = endpoint.replace(`{${param}}`, encodeURIComponent(val));
+          delete payload[param];
+        }
+      }
+
       try {
         let resp;
         if (config.method === 'GET') {
           const query = new URLSearchParams(payload).toString();
-          resp = await fetch(`${config.endpoint}?${query}`);
+          resp = await fetch(query ? `${endpoint}?${query}` : endpoint);
         } else {
-          resp = await fetch(config.endpoint, {
+          resp = await fetch(endpoint, {
             method: config.method || 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)

--- a/search.html
+++ b/search.html
@@ -25,8 +25,20 @@
     <h1 class="mb-3">Buscar Proyecto</h1>
     <form id="searchForm" class="form">
       <div class="mb-3">
-        <label for="term" class="form-label">Filtro</label>
-        <input type="text" class="form-control" id="term" name="term" placeholder="Ingrese búsqueda" />
+        <label for="title" class="form-label">Título</label>
+        <input type="text" class="form-control" id="title" name="title" placeholder="Título" />
+      </div>
+      <div class="mb-3">
+        <label for="state" class="form-label">Estado</label>
+        <input type="text" class="form-control" id="state" name="state" placeholder="Estado" />
+      </div>
+      <div class="mb-3">
+        <label for="applicant" class="form-label">Aplicante</label>
+        <input type="text" class="form-control" id="applicant" name="applicant" placeholder="Usuario creador" />
+      </div>
+      <div class="mb-3">
+        <label for="approver" class="form-label">Aprobador</label>
+        <input type="text" class="form-control" id="approver" name="approver" placeholder="Usuario aprobador" />
       </div>
       <button type="submit" class="btn btn-success">Buscar</button>
     </form>
@@ -39,6 +51,12 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/forms.js"></script>
-  <script>setupForm({formId: 'searchForm', endpoint: 'https://localhost:7062/api/Project/search', method: 'GET'});</script>
+  <script>
+    setupForm({
+      formId: 'searchForm',
+      endpoint: 'https://localhost:7062/api/Project',
+      method: 'GET'
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement dynamic path parameters in `setupForm`
- update approval form fields and connect to `/api/Project/{id}/decision`
- update edit form to use `/api/Project/{id}` and include duration field
- improve search form with title/state/applicant/approver filters and adjust endpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f12ae65388324ac015f6177088a9b