### PR TITLE
Improve result messages for project actions

### DIFF
--- a/approve.html
+++ b/approve.html
@@ -60,7 +60,15 @@
       formId: 'approveForm',
       endpoint: 'https://localhost:7062/api/Project/{id}/decision',
       method: 'PUT',
-      pathParams: ['id']
+      pathParams: ['id'],
+      renderResult: (data, div) => {
+        const decision = data.state || data.decision || '';
+        div.innerHTML =
+          '<div class="alert alert-info d-flex align-items-center">' +
+          '<i class="bi bi-info-circle-fill me-2"></i>' +
+          'Se tomó la decisión: ' + decision +
+          '</div>';
+      }
     });
   </script>
 </body>

--- a/create.html
+++ b/create.html
@@ -63,6 +63,19 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/forms.js"></script>
-  <script>setupForm({formId: 'createForm', endpoint: 'https://localhost:7062/api/Project', method: 'POST'});</script>
+  <script>
+    setupForm({
+      formId: 'createForm',
+      endpoint: 'https://localhost:7062/api/Project',
+      method: 'POST',
+      renderResult: (data, div) => {
+        div.innerHTML =
+          '<div class="alert alert-success d-flex align-items-center">' +
+          '<i class="bi bi-check-circle-fill me-2"></i>' +
+          'Proyecto creado correctamente' +
+          '</div>';
+      }
+    });
+  </script>
 </body>
 </html>

--- a/edit.html
+++ b/edit.html
@@ -56,7 +56,17 @@
       formId: 'editForm',
       endpoint: 'https://localhost:7062/api/Project/{id}',
       method: 'PUT',
-      pathParams: ['id']
+      pathParams: ['id'],
+      renderResult: (data, div) => {
+        div.innerHTML =
+          '<div class="alert alert-success d-flex align-items-center">' +
+          '<i class="bi bi-pencil-fill me-2"></i>' +
+          'Proyecto actualizado' +
+          '</div>' +
+          '<pre>' +
+          JSON.stringify(data, null, 2) +
+          '</pre>';
+      }
     });
   </script>
 </body>

--- a/js/forms.js
+++ b/js/forms.js
@@ -37,17 +37,21 @@ function setupForm(config) {
             body: JSON.stringify(payload)
           });
         }
-        if (!resp.ok) {
-          const text = await resp.text();
-          resultDiv.textContent = `Error ${resp.status}: ${text}`;
-          resultDiv.classList.add('error');
-        } else {
-          const data = await resp.json();
-          resultDiv.textContent = '✅ Operación exitosa:\n' + JSON.stringify(data, null, 2);
-          resultDiv.classList.remove('error');
-          resultDiv.classList.add('success');
-          form.reset();
-        }
+          if (!resp.ok) {
+            const text = await resp.text();
+            resultDiv.textContent = `Error ${resp.status}: ${text}`;
+            resultDiv.classList.add('error');
+          } else {
+            const data = await resp.json();
+            resultDiv.classList.remove('error');
+            resultDiv.classList.add('success');
+            if (typeof config.renderResult === 'function') {
+              config.renderResult(data, resultDiv);
+            } else {
+              resultDiv.textContent = '✅ Operación exitosa:\n' + JSON.stringify(data, null, 2);
+            }
+            form.reset();
+          }
       } catch (err) {
         resultDiv.textContent = `Error de red: ${err.message}`;
         resultDiv.classList.add('error');

--- a/search.html
+++ b/search.html
@@ -55,7 +55,17 @@
     setupForm({
       formId: 'searchForm',
       endpoint: 'https://localhost:7062/api/Project',
-      method: 'GET'
+      method: 'GET',
+      renderResult: (data, div) => {
+        const projects = Array.isArray(data) ? data : [data];
+        div.innerHTML = projects
+          .map(p =>
+            '<div class="card mb-3"><div class="card-body"><pre>' +
+            JSON.stringify(p, null, 2) +
+            '</pre></div></div>'
+          )
+          .join('');
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add render hooks in `setupForm` for custom result display
- show custom success alert when creating a project
- show details after editing a project
- display decision after approving a project
- show search results as cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f3aeee0808324a91487c3290404d6