### PR TITLE
Improve search filters and error alerts

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -37,9 +37,22 @@ function setupForm(config) {
           });
         }
           if (!resp.ok) {
-            const text = await resp.text();
-            resultDiv.textContent = `Error ${resp.status}: ${text}`;
+            let message = `Error ${resp.status}`;
+            try {
+              const errData = await resp.json();
+              message = errData.message || errData.title || JSON.stringify(errData);
+            } catch {
+              try {
+                message = await resp.text();
+              } catch {}
+            }
+            resultDiv.innerHTML =
+              '<div class="alert alert-danger d-flex align-items-center">' +
+              '<i class="bi bi-exclamation-triangle-fill me-2"></i>' +
+              message +
+              '</div>';
             resultDiv.classList.add('error');
+            resultDiv.classList.remove('success');
           } else {
             const data = await resp.json();
             resultDiv.classList.remove('error');
@@ -47,13 +60,22 @@ function setupForm(config) {
             if (typeof config.renderResult === 'function') {
               config.renderResult(data, resultDiv);
             } else {
-              resultDiv.textContent = '✅ Operación exitosa:\n' + JSON.stringify(data, null, 2);
+              resultDiv.innerHTML =
+                '<div class="alert alert-success d-flex align-items-center">' +
+                '<i class="bi bi-check-circle-fill me-2"></i>' +
+                'Operación exitosa' +
+                '</div>';
             }
             form.reset();
           }
       } catch (err) {
-        resultDiv.textContent = `Error de red: ${err.message}`;
+        resultDiv.innerHTML =
+          '<div class="alert alert-danger d-flex align-items-center">' +
+          '<i class="bi bi-exclamation-triangle-fill me-2"></i>' +
+          `Error de red: ${err.message}` +
+          '</div>';
         resultDiv.classList.add('error');
+        resultDiv.classList.remove('success');
       }
     });
 }

--- a/js/search.js
+++ b/js/search.js
@@ -1,4 +1,27 @@
-document.addEventListener('DOMContentLoaded', () => {
+async function populateSelect(id, endpoint) {
+  const select = document.getElementById(id);
+  if (!select) return;
+  try {
+    const resp = await fetch(`${API_BASE_URL}${endpoint}`);
+    if (resp.ok) {
+      const items = await resp.json();
+      const options = items
+        .map(i => {
+          const label = i.name || i.fullName || i.title || i.username || i.email || i.id;
+          return `<option value="${i.id}">${label}</option>`;
+        })
+        .join('');
+      select.innerHTML = '<option value="">Seleccione...</option>' + options;
+    }
+  } catch (err) {
+    console.error('Error cargando opciones', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await populateSelect('state', '/api/ProjectState');
+  await populateSelect('applicant', '/api/User');
+  await populateSelect('approver', '/api/User');
   setupForm({
     formId: 'searchForm',
     endpoint: `${API_BASE_URL}/api/Project`,

--- a/search.html
+++ b/search.html
@@ -30,15 +30,15 @@
       </div>
       <div class="mb-3">
         <label for="state" class="form-label">Estado</label>
-        <input type="text" class="form-control" id="state" name="state" placeholder="Estado" />
+        <select class="form-select" id="state" name="state"></select>
       </div>
       <div class="mb-3">
         <label for="applicant" class="form-label">Aplicante</label>
-        <input type="text" class="form-control" id="applicant" name="applicant" placeholder="Usuario creador" />
+        <select class="form-select" id="applicant" name="applicant"></select>
       </div>
       <div class="mb-3">
         <label for="approver" class="form-label">Aprobador</label>
-        <input type="text" class="form-control" id="approver" name="approver" placeholder="Usuario aprobador" />
+        <select class="form-select" id="approver" name="approver"></select>
       </div>
       <button type="submit" class="btn btn-success">Buscar</button>
     </form>


### PR DESCRIPTION
## Summary
- use selects for status, applicant and approver filters
- fetch options from API for those selects
- show errors with Bootstrap alerts across all forms

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68507447d27c832492bf38318fea653b