### PR TITLE
Improve search cards and state options

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -18,8 +18,43 @@ async function populateSelect(id, endpoint) {
   }
 }
 
+const STATE_OPTIONS = [
+  { id: 1, name: 'Pendiente' },
+  { id: 2, name: 'Aprobado' },
+  { id: 3, name: 'Rechazado' },
+  { id: 4, name: 'Observado' }
+];
+
+const STATE_LABELS = {
+  1: { text: 'Pendiente', class: 'secondary' },
+  2: { text: 'Aprobado', class: 'success' },
+  3: { text: 'Rechazado', class: 'danger' },
+  4: { text: 'Observado', class: 'warning' }
+};
+
+function getValue(obj, keys) {
+  for (const k of keys) {
+    if (obj[k] !== undefined && obj[k] !== null) return obj[k];
+  }
+  return '';
+}
+
+function stateInfo(value) {
+  const key = Number(value);
+  if (STATE_LABELS[key]) return STATE_LABELS[key];
+  const val = value || 'Desconocido';
+  return { text: val, class: 'secondary' };
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   await populateSelect('state', '/api/ProjectState');
+  const stateSelect = document.getElementById('state');
+  if (stateSelect && stateSelect.options.length <= 1) {
+    stateSelect.innerHTML =
+      '<option value="">Seleccione...</option>' +
+      STATE_OPTIONS.map(o => `<option value="${o.id}">${o.name}</option>`).join('');
+  }
+
   await populateSelect('applicant', '/api/User');
   await populateSelect('approver', '/api/User');
   setupForm({
@@ -28,13 +63,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     method: 'GET',
     renderResult: (data, div) => {
       const projects = Array.isArray(data) ? data : [data];
-
-      function renderDetails(obj) {
-        const items = Object.entries(obj)
-          .map(([k, v]) => `<li class="list-group-item"><strong>${k}:</strong> ${v}</li>`)
-          .join('');
-        return `<ul class="list-group list-group-flush">${items}</ul>`;
-      }
 
       function actionButtons(id) {
         if (!id) return '';
@@ -50,17 +78,46 @@ document.addEventListener('DOMContentLoaded', async () => {
         );
       }
 
-      div.innerHTML = projects
-        .map(p => {
-          const details = renderDetails(p);
-          return (
-            '<div class="card mb-3"><div class="card-body">' +
-            details +
-            actionButtons(p.id) +
-            '</div></div>'
-          );
-        })
-        .join('');
+      function renderCard(p) {
+        const id = getValue(p, ['id', 'projectId']);
+        const title = getValue(p, ['title', 'name']);
+        const description = getValue(p, ['description', 'desc']);
+        const amount = getValue(p, ['estimatedAmount', 'amount']);
+        const duration = getValue(p, ['estimatedDuration', 'duration']);
+        const area =
+          getValue(p, ['areaName', 'area']) ||
+          (p.area && (p.area.name || p.area.title)) ||
+          getValue(p, ['areaId']);
+        const type =
+          getValue(p, ['typeName', 'type', 'projectType']) ||
+          (p.projectType && (p.projectType.name || p.projectType.title)) ||
+          getValue(p, ['typeId']);
+        const stateVal = getValue(p, ['state', 'status', 'stateId']);
+        const info = stateInfo(stateVal);
+
+        const items =
+          `<li class="list-group-item"><strong>ID del proyecto:</strong> ${id}</li>` +
+          `<li class="list-group-item"><strong>Titulo:</strong> ${title}</li>` +
+          `<li class="list-group-item"><strong>Descripcion:</strong> ${description}</li>` +
+          `<li class="list-group-item"><strong>Monto:</strong> ${amount}</li>` +
+          `<li class="list-group-item"><strong>Duracion (en dias):</strong> ${duration}</li>` +
+          `<li class="list-group-item"><strong>Area:</strong> ${area}</li>` +
+          `<li class="list-group-item"><strong>Tipo:</strong> ${type}</li>` +
+          `<li class="list-group-item"><strong>Estado:</strong> <div class="alert alert-${info.class} mb-0 py-1">${info.text}</div></li>`;
+
+        return (
+          '<div class="card mb-3">' +
+          '<div class="card-header bg-info text-white">' +
+          '<i class="bi bi-info-circle me-2"></i>Detalle del proyecto' +
+          '</div>' +
+          '<div class="card-body">' +
+          `<ul class="list-group list-group-flush mb-3">${items}</ul>` +
+          actionButtons(id) +
+          '</div></div>'
+        );
+      }
+
+      div.innerHTML = projects.map(renderCard).join('');
     }
   });
 });


### PR DESCRIPTION
## Summary
- make search result cards show explicit project details with styled state badges
- add fallback search dropdown options for project state

## Testing
- `npx eslint js/search.js` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68507be6d2308324b4a19d3d7b223f00