### PR TITLE
Improve forms and project info display

### DIFF
--- a/approve.html
+++ b/approve.html
@@ -49,6 +49,7 @@
         <input type="text" class="form-control" id="observation" name="observation" placeholder="Mensaje" />
       </div>
       <button type="submit" class="btn btn-success">Ejecutar</button>
+      <button type="button" id="clearBtn" class="btn btn-secondary ms-2">Limpiar</button>
     </form>
     <div id="result" class="result"></div>
   </main>

--- a/create.html
+++ b/create.html
@@ -53,6 +53,7 @@
         <select class="form-select" id="typeId" name="typeId"></select>
       </div>
       <button type="submit" class="btn btn-success">Crear proyecto</button>
+      <button type="button" id="clearBtn" class="btn btn-secondary ms-2">Limpiar</button>
     </form>
     <div id="result" class="result"></div>
   </main>
@@ -64,6 +65,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/config.js"></script>
   <script src="js/forms.js"></script>
+  <script src="js/projectCard.js"></script>
   <script src="js/create.js"></script>
 </body>
 </html>

--- a/edit.html
+++ b/edit.html
@@ -41,6 +41,7 @@
         <input type="number" class="form-control" id="duration" name="duration" placeholder="Ej: 10" />
       </div>
       <button type="submit" class="btn btn-success">Guardar cambios</button>
+      <button type="button" id="clearBtn" class="btn btn-secondary ms-2">Limpiar</button>
     </form>
     <div id="result" class="result"></div>
   </main>
@@ -52,6 +53,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/config.js"></script>
   <script src="js/forms.js"></script>
+  <script src="js/projectCard.js"></script>
   <script src="js/edit.js"></script>
 </body>
 </html>

--- a/js/approve.js
+++ b/js/approve.js
@@ -67,11 +67,31 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   }
 
+  const clearBtn = document.getElementById('clearBtn');
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      document.getElementById('approveForm').reset();
+      const result = document.getElementById('result');
+      if (result) result.innerHTML = '';
+      if (proposalId) {
+        document.getElementById('proposalId').value = proposalId;
+        populateSteps(proposalId);
+      }
+    });
+  }
+
   setupForm({
     formId: 'approveForm',
     endpoint: `${API_BASE_URL}/api/Project/{proposalId}/decision`,
     method: 'PATCH',
     pathParams: ['proposalId'],
+    reset: false,
+    afterSuccess: () => {
+      if (proposalId) {
+        document.getElementById('proposalId').value = proposalId;
+        populateSteps(proposalId);
+      }
+    },
     renderResult: (data, div) => {
       const decision = (data.state || data.decision || '').toString().toLowerCase();
       let alertClass = 'info';

--- a/js/create.js
+++ b/js/create.js
@@ -24,16 +24,27 @@ document.addEventListener('DOMContentLoaded', () => {
   populateSelect('user', '/api/User');
   populateSelect('typeId', '/api/ProjectType');
 
+  const clearBtn = document.getElementById('clearBtn');
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      document.getElementById('createForm').reset();
+      const result = document.getElementById('result');
+      if (result) result.innerHTML = '';
+    });
+  }
+
   setupForm({
     formId: 'createForm',
     endpoint: `${API_BASE_URL}/api/Project`,
     method: 'POST',
     renderResult: (data, div) => {
+      const card = renderProjectCard ? renderProjectCard(data) : '';
       div.innerHTML =
         '<div class="alert alert-success d-flex align-items-center">' +
         '<i class="bi bi-check-circle-fill me-2"></i>' +
         'Proyecto creado correctamente' +
-        '</div>';
+        '</div>' +
+        card;
     }
   });
 });

--- a/js/edit.js
+++ b/js/edit.js
@@ -1,10 +1,3 @@
-function renderDetails(obj) {
-  const items = Object.entries(obj)
-    .map(([k, v]) => `<li class="list-group-item"><strong>${k}:</strong> ${v}</li>`)
-    .join('');
-  return `<div class="card mt-3"><ul class="list-group list-group-flush">${items}</ul></div>`;
-}
-
 document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
   for (const [key, value] of params.entries()) {
@@ -12,6 +5,15 @@ document.addEventListener('DOMContentLoaded', () => {
     if (input) {
       input.value = value;
     }
+  }
+
+  const clearBtn = document.getElementById('clearBtn');
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      document.getElementById('editForm').reset();
+      const result = document.getElementById('result');
+      if (result) result.innerHTML = '';
+    });
   }
 
   setupForm({
@@ -30,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const resp = await fetch(`${API_BASE_URL}/api/Project/${id}`);
         if (resp.ok) {
           const project = await resp.json();
-          div.innerHTML += renderDetails(project);
+          div.innerHTML += renderProjectCard(project);
         }
       } catch {}
     }

--- a/js/forms.js
+++ b/js/forms.js
@@ -27,7 +27,10 @@ function setupForm(config) {
       try {
         let resp;
         if (config.method === 'GET') {
-          const query = new URLSearchParams(payload).toString();
+          const filtered = Object.fromEntries(
+            Object.entries(payload).filter(([_, v]) => v !== '' && v !== null && v !== undefined)
+          );
+          const query = new URLSearchParams(filtered).toString();
           resp = await fetch(query ? `${endpoint}?${query}` : endpoint);
         } else {
           resp = await fetch(endpoint, {
@@ -66,7 +69,12 @@ function setupForm(config) {
                 'Operación exitosa' +
                 '</div>';
             }
-            form.reset();
+            if (config.reset !== false) {
+              form.reset();
+            }
+            if (typeof config.afterSuccess === 'function') {
+              config.afterSuccess(data, form);
+            }
           }
       } catch (err) {
         resultDiv.innerHTML =

--- a/js/projectCard.js
+++ b/js/projectCard.js
@@ -1,0 +1,63 @@
+const STATE_LABELS = {
+  1: { text: 'Pendiente', class: 'secondary' },
+  2: { text: 'Aprobado', class: 'success' },
+  3: { text: 'Rechazado', class: 'danger' },
+  4: { text: 'Observado', class: 'warning' }
+};
+
+function getValue(obj, keys) {
+  for (const k of keys) {
+    if (obj[k] !== undefined && obj[k] !== null) return obj[k];
+  }
+  return '';
+}
+
+function stateInfo(value) {
+  const key = Number(value);
+  if (STATE_LABELS[key]) return STATE_LABELS[key];
+  const val = value || 'Desconocido';
+  return { text: val, class: 'secondary' };
+}
+
+function renderProjectCard(p, actionButtons) {
+  const id = getValue(p, ['id', 'projectId']);
+  const title = getValue(p, ['title', 'name']);
+  const description = getValue(p, ['description', 'desc']);
+  const amount = getValue(p, ['estimatedAmount', 'amount']);
+  const duration = getValue(p, ['estimatedDuration', 'duration']);
+  const area =
+    getValue(p, ['areaName', 'area']) ||
+    (p.area && (p.area.name || p.area.title)) ||
+    getValue(p, ['areaId']);
+  const type =
+    getValue(p, ['typeName', 'type', 'projectType']) ||
+    (p.projectType && (p.projectType.name || p.projectType.title)) ||
+    getValue(p, ['typeId']);
+  const stateVal = getValue(p, ['state', 'status', 'stateId']);
+  const info = stateInfo(stateVal);
+
+  const items =
+    `<li class="list-group-item"><strong>ID del proyecto:</strong> ${id}</li>` +
+    `<li class="list-group-item"><strong>Titulo:</strong> ${title}</li>` +
+    `<li class="list-group-item"><strong>Descripcion:</strong> ${description}</li>` +
+    `<li class="list-group-item"><strong>Monto:</strong> ${amount}</li>` +
+    `<li class="list-group-item"><strong>Duracion (en dias):</strong> ${duration}</li>` +
+    `<li class="list-group-item"><strong>Area:</strong> ${area}</li>` +
+    `<li class="list-group-item"><strong>Tipo:</strong> ${type}</li>` +
+    `<li class="list-group-item"><strong>Estado:</strong> <div class="alert alert-${info.class} mb-0 py-1">${info.text}</div></li>`;
+
+  return (
+    '<div class="card mb-3">' +
+    '<div class="card-header bg-info text-white">' +
+    '<i class="bi bi-info-circle me-2"></i>Detalle del proyecto' +
+    '</div>' +
+    '<div class="card-body">' +
+    `<ul class="list-group list-group-flush mb-3">${items}</ul>` +
+    (typeof actionButtons === 'function' ? actionButtons(id) : '') +
+    '</div></div>'
+  );
+}
+
+window.renderProjectCard = renderProjectCard;
+window.stateInfo = stateInfo;
+

--- a/js/search.js
+++ b/js/search.js
@@ -25,26 +25,6 @@ const STATE_OPTIONS = [
   { id: 4, name: 'Observado' }
 ];
 
-const STATE_LABELS = {
-  1: { text: 'Pendiente', class: 'secondary' },
-  2: { text: 'Aprobado', class: 'success' },
-  3: { text: 'Rechazado', class: 'danger' },
-  4: { text: 'Observado', class: 'warning' }
-};
-
-function getValue(obj, keys) {
-  for (const k of keys) {
-    if (obj[k] !== undefined && obj[k] !== null) return obj[k];
-  }
-  return '';
-}
-
-function stateInfo(value) {
-  const key = Number(value);
-  if (STATE_LABELS[key]) return STATE_LABELS[key];
-  const val = value || 'Desconocido';
-  return { text: val, class: 'secondary' };
-}
 
 document.addEventListener('DOMContentLoaded', async () => {
   await populateSelect('state', '/api/ProjectState');
@@ -57,6 +37,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   await populateSelect('applicant', '/api/User');
   await populateSelect('approver', '/api/User');
+  const clearBtn = document.getElementById('clearBtn');
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      document.getElementById('searchForm').reset();
+      const result = document.getElementById('result');
+      if (result) result.innerHTML = '';
+    });
+  }
   setupForm({
     formId: 'searchForm',
     endpoint: `${API_BASE_URL}/api/Project`,
@@ -78,46 +66,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         );
       }
 
-      function renderCard(p) {
-        const id = getValue(p, ['id', 'projectId']);
-        const title = getValue(p, ['title', 'name']);
-        const description = getValue(p, ['description', 'desc']);
-        const amount = getValue(p, ['estimatedAmount', 'amount']);
-        const duration = getValue(p, ['estimatedDuration', 'duration']);
-        const area =
-          getValue(p, ['areaName', 'area']) ||
-          (p.area && (p.area.name || p.area.title)) ||
-          getValue(p, ['areaId']);
-        const type =
-          getValue(p, ['typeName', 'type', 'projectType']) ||
-          (p.projectType && (p.projectType.name || p.projectType.title)) ||
-          getValue(p, ['typeId']);
-        const stateVal = getValue(p, ['state', 'status', 'stateId']);
-        const info = stateInfo(stateVal);
-
-        const items =
-          `<li class="list-group-item"><strong>ID del proyecto:</strong> ${id}</li>` +
-          `<li class="list-group-item"><strong>Titulo:</strong> ${title}</li>` +
-          `<li class="list-group-item"><strong>Descripcion:</strong> ${description}</li>` +
-          `<li class="list-group-item"><strong>Monto:</strong> ${amount}</li>` +
-          `<li class="list-group-item"><strong>Duracion (en dias):</strong> ${duration}</li>` +
-          `<li class="list-group-item"><strong>Area:</strong> ${area}</li>` +
-          `<li class="list-group-item"><strong>Tipo:</strong> ${type}</li>` +
-          `<li class="list-group-item"><strong>Estado:</strong> <div class="alert alert-${info.class} mb-0 py-1">${info.text}</div></li>`;
-
-        return (
-          '<div class="card mb-3">' +
-          '<div class="card-header bg-info text-white">' +
-          '<i class="bi bi-info-circle me-2"></i>Detalle del proyecto' +
-          '</div>' +
-          '<div class="card-body">' +
-          `<ul class="list-group list-group-flush mb-3">${items}</ul>` +
-          actionButtons(id) +
-          '</div></div>'
-        );
-      }
-
-      div.innerHTML = projects.map(renderCard).join('');
+      div.innerHTML = projects
+        .map(p => renderProjectCard(p, actionButtons))
+        .join('');
     }
   });
 });

--- a/search.html
+++ b/search.html
@@ -41,6 +41,7 @@
         <select class="form-select" id="approver" name="approver"></select>
       </div>
       <button type="submit" class="btn btn-success">Buscar</button>
+      <button type="button" id="clearBtn" class="btn btn-secondary ms-2">Limpiar</button>
     </form>
     <div id="result" class="result"></div>
   </main>
@@ -52,6 +53,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/config.js"></script>
   <script src="js/forms.js"></script>
+  <script src="js/projectCard.js"></script>
   <script src="js/search.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refine query building and add success callbacks in `forms.js`
- keep proposal ID when approving and support clearing forms
- show project card after creation and edition
- share project card rendering helper
- add `Limpiar` buttons on forms

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68507ec052d48324a2a8a18f788701ac