### PR TITLE
Fix search filter by state

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -25,6 +25,34 @@ const STATE_OPTIONS = [
   { id: 4, name: 'Observado' }
 ];
 
+function getProjectStateId(p) {
+  const props = [
+    'state',
+    'status',
+    'approvalStatus',
+    'stateId',
+    'statusId',
+    'approvalStatusId',
+    'State',
+    'Status',
+    'StateId',
+    'StatusId'
+  ];
+  for (const key of props) {
+    if (p[key] !== undefined && p[key] !== null) {
+      let val = p[key];
+      if (typeof val === 'object') {
+        if (val.id !== undefined && val.id !== null) return val.id;
+        if (val.stateId !== undefined && val.stateId !== null) return val.stateId;
+        if (val.statusId !== undefined && val.statusId !== null) return val.statusId;
+        continue;
+      }
+      return val;
+    }
+  }
+  return undefined;
+}
+
 
 document.addEventListener('DOMContentLoaded', async () => {
   await populateSelect('state', '/api/ProjectState');
@@ -57,6 +85,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (stateFilter && stateFilter.value) {
         const value = stateFilter.value;
         filtered = projects.filter(p => {
+          const stateVal = getProjectStateId(p);
+          return stateVal !== undefined && stateVal !== null && String(stateVal) === value;
         });
       }
 


### PR DESCRIPTION
## Summary
- add `getProjectStateId` helper to handle various API shapes
- filter projects by numeric state ID using helper

## Testing
- `npx --version`


------
https://chatgpt.com/codex/tasks/task_e_68508ea4a7ec8324af47617f223f3cc6