### PR TITLE
Mejoras visuales y feedback de carga

### DIFF
--- a/approve.html
+++ b/approve.html
@@ -21,7 +21,7 @@
           <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
             <i class="bi bi-list"></i>
           </button>
-          <ul class="dropdown-menu dropdown-menu-end" id="proposalDropdown"></ul>
+          <ul class="dropdown-menu dropdown-menu-end project-dropdown-menu" id="proposalDropdown"></ul>
         </div>
       </div>
       <div class="mb-3">
@@ -42,7 +42,7 @@
       </div>
       <div class="mb-3">
         <label for="observation" class="form-label">Observación</label>
-        <input type="text" class="form-control" id="observation" name="observation" placeholder="Mensaje" />
+        <input type="text" class="form-control" id="observation" name="observation" />
       </div>
       <button type="submit" class="btn btn-success">Ejecutar</button>
       <button type="button" id="clearBtn" class="btn btn-secondary ms-2">Limpiar</button>
@@ -53,6 +53,9 @@
   <footer class="footer">
     <p class="footer__text">© 2025 Mi Empresa</p>
   </footer>
+  <div id="loadingOverlay" class="loading-overlay d-none">
+    <div class="spinner-border text-light" role="status"></div>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="src/config.js"></script>

--- a/create.html
+++ b/create.html
@@ -24,11 +24,11 @@
       </div>
       <div class="mb-3">
         <label for="estimatedAmount" class="form-label">Monto Estimado</label>
-        <input type="number" class="form-control" id="estimatedAmount" name="estimatedAmount" placeholder="Ej: 45000" />
+        <input type="number" class="form-control" id="estimatedAmount" name="estimatedAmount" />
       </div>
       <div class="mb-3">
         <label for="estimatedDuration" class="form-label">Duración Estimada (días)</label>
-        <input type="number" class="form-control" id="estimatedDuration" name="estimatedDuration" placeholder="Ej: 15" />
+        <input type="number" class="form-control" id="estimatedDuration" name="estimatedDuration" />
       </div>
       <div class="mb-3">
         <label for="areaId" class="form-label">Área</label>
@@ -51,6 +51,9 @@
   <footer class="footer">
     <p class="footer__text">© 2025 Mi Empresa</p>
   </footer>
+  <div id="loadingOverlay" class="loading-overlay d-none">
+    <div class="spinner-border text-light" role="status"></div>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="src/config.js"></script>

--- a/edit.html
+++ b/edit.html
@@ -21,7 +21,7 @@
           <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
             <i class="bi bi-list"></i>
           </button>
-          <ul class="dropdown-menu dropdown-menu-end" id="projectDropdown"></ul>
+          <ul class="dropdown-menu dropdown-menu-end project-dropdown-menu" id="projectDropdown"></ul>
         </div>
       </div>
       <div class="mb-3">
@@ -34,7 +34,7 @@
       </div>
       <div class="mb-3">
         <label for="duration" class="form-label">Duración Estimada (días)</label>
-        <input type="number" class="form-control" id="duration" name="duration" placeholder="Ej: 10" />
+        <input type="number" class="form-control" id="duration" name="duration" />
       </div>
       <button type="submit" class="btn btn-success">Guardar cambios</button>
       <button type="button" id="clearBtn" class="btn btn-secondary ms-2">Limpiar</button>
@@ -45,6 +45,9 @@
   <footer class="footer">
     <p class="footer__text">© 2025 Mi Empresa</p>
   </footer>
+  <div id="loadingOverlay" class="loading-overlay d-none">
+    <div class="spinner-border text-light" role="status"></div>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="src/config.js"></script>

--- a/search.html
+++ b/search.html
@@ -39,6 +39,9 @@
   <footer class="footer">
     <p class="footer__text">© 2025 Mi Empresa</p>
   </footer>
+  <div id="loadingOverlay" class="loading-overlay d-none">
+    <div class="spinner-border text-light" role="status"></div>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="src/config.js"></script>

--- a/src/approve.js
+++ b/src/approve.js
@@ -50,20 +50,24 @@ async function populateSteps(proposalId) {
           let icon = '';
           let color = '';
           let disabled = false;
+          let cls = '';
           if (state === 2) {
             icon = '✓';
             color = 'color: #6c757d;';
             disabled = true;
+            cls = 'text-muted';
           } else if (state === 1 || state === 4) {
             icon = state === 4 ? '⚠' : '⌛';
             disabled = firstPending && s.id !== firstPending.id;
+            if (disabled) cls = 'text-muted';
           } else if (state === 3) {
             icon = '✖';
             color = 'color: #dc3545;';
             disabled = true;
+            cls = 'text-danger';
           }
           return (
-            `<option value="${s.id}" ${disabled ? 'disabled' : ''} style="${color}">` +
+            `<option value="${s.id}" ${disabled ? 'disabled' : ''} class="${cls}" style="${color}">` +
             `${icon} Paso ${s.stepOrder} - ${roleName}</option>`
           );
         })

--- a/src/forms.js
+++ b/src/forms.js
@@ -2,8 +2,12 @@ function setupForm(config) {
   const form = document.getElementById(config.formId);
   if (!form) return;
   const resultDiv = document.getElementById('result');
+  const overlay = document.getElementById('loadingOverlay');
   form.addEventListener('submit', async (e) => {
       e.preventDefault();
+      if (overlay) overlay.classList.remove('d-none');
+      const submitBtn = form.querySelector('[type="submit"]');
+      if (submitBtn) submitBtn.disabled = true;
       const formData = new FormData(form);
       const payload = {};
       for (const [key, value] of formData.entries()) {
@@ -84,6 +88,9 @@ function setupForm(config) {
           '</div>';
         resultDiv.classList.add('error');
         resultDiv.classList.remove('success');
+      } finally {
+        if (overlay) overlay.classList.add('d-none');
+        if (submitBtn) submitBtn.disabled = false;
       }
     });
 }

--- a/style.css
+++ b/style.css
@@ -172,3 +172,32 @@ nav.navbar .nav-link:hover::after {
   background: linear-gradient(45deg, #198754, #28c76f);
   color: #fff;
 }
+
+/* Loading overlay */
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1050;
+}
+
+/* Dropdown list improvements */
+.project-dropdown-menu {
+  max-height: 250px;
+  overflow-y: auto;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  padding: 0.25rem 0;
+}
+.project-dropdown-menu .dropdown-item {
+  border-radius: 4px;
+}
+.project-dropdown-menu .dropdown-item:hover {
+  background-color: #e9ecef;
+}


### PR DESCRIPTION
## Resumen
- se añadió un overlay animado para indicar carga en todos los formularios
- se quitaron los mensajes de ejemplo de los campos numéricos y de observación
- los menús desplegables de IDs ahora poseen un estilo más vistoso
- se resaltan de manera distinta los pasos aprobados o futuros al seleccionar paso

## Testing
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850d40c7db883248285d47a34507596