### PR TITLE
Add placeholders and default state option

### DIFF
--- a/approve.html
+++ b/approve.html
@@ -35,6 +35,7 @@
       <div class="mb-3">
         <label for="status" class="form-label">Estado</label>
         <select class="form-select" id="status" name="status">
+          <option value="">Seleccione...</option>
           <option value="2">Aprobado</option>
           <option value="3">Rechazado</option>
           <option value="4">Observado</option>
@@ -42,7 +43,13 @@
       </div>
       <div class="mb-3">
         <label for="observation" class="form-label">Observación</label>
-        <input type="text" class="form-control" id="observation" name="observation" />
+        <input
+          type="text"
+          class="form-control"
+          id="observation"
+          name="observation"
+          placeholder="Observación"
+        />
       </div>
       <button type="submit" class="btn btn-success">Ejecutar</button>
       <button type="button" id="clearBtn" class="btn btn-secondary ms-2">Limpiar</button>

--- a/create.html
+++ b/create.html
@@ -24,11 +24,23 @@
       </div>
       <div class="mb-3">
         <label for="estimatedAmount" class="form-label">Monto Estimado</label>
-        <input type="number" class="form-control" id="estimatedAmount" name="estimatedAmount" />
+        <input
+          type="number"
+          class="form-control"
+          id="estimatedAmount"
+          name="estimatedAmount"
+          placeholder="Monto"
+        />
       </div>
       <div class="mb-3">
         <label for="estimatedDuration" class="form-label">Duración Estimada (días)</label>
-        <input type="number" class="form-control" id="estimatedDuration" name="estimatedDuration" />
+        <input
+          type="number"
+          class="form-control"
+          id="estimatedDuration"
+          name="estimatedDuration"
+          placeholder="Duración"
+        />
       </div>
       <div class="mb-3">
         <label for="areaId" class="form-label">Área</label>

--- a/edit.html
+++ b/edit.html
@@ -34,7 +34,13 @@
       </div>
       <div class="mb-3">
         <label for="duration" class="form-label">Duración Estimada (días)</label>
-        <input type="number" class="form-control" id="duration" name="duration" />
+        <input
+          type="number"
+          class="form-control"
+          id="duration"
+          name="duration"
+          placeholder="Duración"
+        />
       </div>
       <button type="submit" class="btn btn-success">Guardar cambios</button>
       <button type="button" id="clearBtn" class="btn btn-secondary ms-2">Limpiar</button>


### PR DESCRIPTION
## Summary
- show hint text on empty form fields
- add placeholder for approval state select

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850df3601f08324b5c2effb52916c06